### PR TITLE
fix: change width property in StyledTypo

### DIFF
--- a/src/components/common/CustomTable.js
+++ b/src/components/common/CustomTable.js
@@ -52,7 +52,7 @@ const StyledOptionBox = styled(Box)({
 
 const StyledTypo = styled(Typography)(
   ({ accentColumnNum, idxConverter, idx, longWidthColumnNum }) => ({
-    minWidth: longWidthColumnNum === idxConverter(idx + 1) ? "300px" : "180px",
+    width: longWidthColumnNum === idxConverter(idx + 1) ? "300px" : "180px",
     color: accentColumnNum === idxConverter(idx + 1) && "primary.main",
     fontWeight: accentColumnNum === idxConverter(idx + 1) && "bold",
   })


### PR DESCRIPTION
<img width="1390" alt="image" src="https://github.com/user-attachments/assets/f49b9b41-765f-4373-b34d-651974592041" />


과목 이름이 넘치는 현상을 해결하기 위해 minWidth -> width 으로 변경하였습니다.

fixes #95