### PR TITLE
과목 검색 시 교수명, 과목코드 포함 및 대소문자 구분 없이 검색 가능하도록 개선 및 ProgressBar 커서 추가

### DIFF
--- a/src/components/Enroll/Courses.js
+++ b/src/components/Enroll/Courses.js
@@ -18,7 +18,24 @@ export default function Courses({ sideCourses, setSideCourses }) {
     const newArr =
       courseInput === ""
         ? allCourses
-        : allCourses.filter((course) => course.name.includes(courseInput));
+        : allCourses.filter(
+            (course) =>
+              // 과목 이름 확인
+              course.name
+                ?.toLowerCase()
+                .replace(" ", "")
+                .includes(courseInput?.toLowerCase().replace(" ", "")) ||
+              // 과목 교수님 확인
+              course.prof
+                ?.toLowerCase()
+                .replace(" ", "")
+                .includes(courseInput?.toLowerCase().replace(" ", "")) ||
+              //과목 코드 확인
+              course.code
+                ?.toLowerCase()
+                .replace(" ", "")
+                .includes(courseInput?.toLowerCase().replace(" ", ""))
+          );
     newArr.map((elem) => {
       result.push([elem.name, elem.code, elem.prof, elem.id]);
     });
@@ -65,7 +82,7 @@ export default function Courses({ sideCourses, setSideCourses }) {
             </InputAdornment>
           ),
         }}
-        placeholder="과목명 검색"
+        placeholder="과목명 | 교수명 | 과목코드"
       />
 
       <CustomTable

--- a/src/components/common/ProgressBar.js
+++ b/src/components/common/ProgressBar.js
@@ -13,7 +13,7 @@ export default function ProgressBar({ page, setPage }) {
         alignItems: "center",
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center" }}>
+      <Box sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}>
         {[1, 2, 3].map((pageNavNum, index) => (
           <Box
             key={index}


### PR DESCRIPTION
### 과목 검색 시 교수명, 과목코드 포함 및 대소문자 구분 없이 검색 

| 항목 | 이미지 |
|------|--------|
| **Placeholder 수정** | ![Placeholder 수정](https://github.com/user-attachments/assets/f195e2f3-f3f0-4eca-861b-34c4040a369d) |
| **영문 대소문자 구분 제거** | ![영문 대소문자 구분 제거](https://github.com/user-attachments/assets/3a065ef3-e597-4f8e-8e2e-eb3a28d008da) |
| **교수명 검색** | ![교수명 검색](https://github.com/user-attachments/assets/08ea4a54-6b77-41e4-a6e0-36e273e005e7) |
| **과목코드 검색** | ![과목코드 검색](https://github.com/user-attachments/assets/4aafeb8a-4029-4e51-bb0d-eefb621c639e) |


### ProgressBar 커서 추가

<img width="369" alt="image" src="https://github.com/user-attachments/assets/5fe9ec74-c419-46d2-9259-e3418e07aa5e" />

fixes #97 
