### PR TITLE
랭크 페이지 스크롤 뷰 너비 및 토글 버튼 위치 수정

### DIFF
--- a/src/components/Rank/ViewToggleButton.js
+++ b/src/components/Rank/ViewToggleButton.js
@@ -8,7 +8,7 @@ export default function ViewToggleButton({ view, setView }) {
     setView(nextView);
   };
   return (
-    <Stack direction="row" justifyContent="end" width="100%">
+    <Stack direction="row" justifyContent="end" width="99%">
       <ToggleButtonGroup
         size="small"
         orientation="horizontal"

--- a/src/pages/Rank/Rank.js
+++ b/src/pages/Rank/Rank.js
@@ -21,7 +21,8 @@ import RankGridView from "../../components/Rank/RankGridView";
 const StyledScrollBox = styled(Box)({
   maxWidth: "1280px",
   width: "100%",
-  overflow: "scroll",
+  overflowX: "auto",
+  overflowY: "hidden",
 });
 
 export default function Rank() {

--- a/src/pages/Rank/Rank.js
+++ b/src/pages/Rank/Rank.js
@@ -19,7 +19,7 @@ import RankListView from "../../components/Rank/RankListView";
 import RankGridView from "../../components/Rank/RankGridView";
 
 const StyledScrollBox = styled(Box)({
-  maxWidth: "1245px",
+  maxWidth: "1280px",
   width: "100%",
   overflow: "scroll",
 });


### PR DESCRIPTION
## 변경사항
1. components/Rank/ViewToggleButton.js의 Stack의 width를 100% -> 99%로 조정
2. pages/Rank/Rank.js 의 StyledScrollBox의 mawWidth를 1245px -> 1280px 로 조정
---
![image](https://github.com/user-attachments/assets/f4a3c9c7-8ee7-4ebd-88bf-22183b720fc1)
*랭크 뷰에서 맨 오른쪽 카드가 잘리지 않도록 개선*

---
![image](https://github.com/user-attachments/assets/781d46d8-ddbb-4c1d-91e0-9de9e600373d)
![image](https://github.com/user-attachments/assets/f256deb3-4640-405d-8779-6f151552c55f) 
*기존 - 하단에 스크롤 바 2개*

![image](https://github.com/user-attachments/assets/3c7ca7fd-f8c0-4b69-9c10-d936d7c65b3b)
![image](https://github.com/user-attachments/assets/a3571152-749d-417f-a786-4d16d67d47d7)
*수정 후 - 불필요한 하단 스크롤바 제거*

fixes #99 