### PR TITLE
Style/137 sidebar collapse ui

### DIFF
--- a/src/components/GoogleButton.tsx
+++ b/src/components/GoogleButton.tsx
@@ -10,6 +10,8 @@ import { toast } from "sonner";
 import { useAuth } from "src/hooks/auth";
 import { userLogin } from "../apis/users";
 import { isRegisterModalState, userLoginInfoState } from "../store/HISAtom";
+import { useSidebar } from "@/components/ui/sidebar";
+
 
 export interface JwtHIStudyPayload extends JwtPayload {
   hd: string;
@@ -76,8 +78,11 @@ export default function GoogleButton() {
       });
   };
 
+  const { state } = useSidebar();
+
   return (
     <GoogleLogin
+      type={state === "collapsed" ? "icon" : "standard"}
       onSuccess={(credentialResponse) => onSuccess(credentialResponse)}
       onError={() => {
         console.log("Login Failed");

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -190,24 +190,19 @@ export function CommonSidebar() {
 
   return (
     <Sidebar collapsible="icon" className="border-r">
-      <SidebarHeader className={cn(
-        "p-3 border-b",
-        "group-data-[collapsible=icon]:px-2"
-      )}>
-        <div className={cn(
-          "flex justify-between items-center",
-          "group-data-[collapsible=icon]:justify-center"
-        )}>
+      <SidebarHeader className="p-3 border-b">
+        <div className="flex justify-between items-center">
           <Link
             to={paths.root}
             className={cn(
               "flex items-center gap-3 p-2 rounded-lg transition-colors duration-200 hover:bg-sidebar-accent",
-              "group-data-[collapsible=icon]:hidden"
+              // collapse 시 왼쪽 마진 17px 감소시켜서 아이콘 위치 조정
+              "group-data-[collapsible=icon]:ml-[-17px]"
             )}
           >
             <span
               className={cn(
-                "font-bold text-3xl text-blue-400",
+                "font-bold text-3xl group-data-[collapsible=icon]:hidden text-blue-400",
                 "transition-opacity duration-200 ease-in-out"
               )}
             >
@@ -215,18 +210,11 @@ export function CommonSidebar() {
             </span>
           </Link>
 
-          <SidebarTrigger 
-            className={cn(
-              "mr-4 group-data-[collapsible=icon]:mr-0"
-            )} 
-          />
+          <SidebarTrigger className="mr-4" />
         </div>
       </SidebarHeader>
 
-      <SidebarContent className={cn(
-        "flex-1 p-3 space-y-1",
-        "group-data-[collapsible=icon]:px-2"
-      )}>
+      <SidebarContent className="flex-1 p-3 space-y-1">
         {/* <RoleSwitcher /> */}
         {filteredNavGroups.map((group) => (
           <SidebarGroup key={group.title}>
@@ -241,13 +229,7 @@ export function CommonSidebar() {
             <SidebarGroupContent>
               <SidebarMenu>
                 {group.items.map((item) => (
-                  <SidebarMenuItem 
-                    key={item.name}
-                    className={cn(
-                      "group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center",
-                      "group-data-[collapsible=icon]:pl-[8px]"
-                    )}
-                  >
+                  <SidebarMenuItem key={item.name}>
                     <SidebarMenuButton
                       asChild
                       isActive={isActive(item.href)}
@@ -259,9 +241,10 @@ export function CommonSidebar() {
                       }}
                       className={cn(
                         "h-10 justify-start gap-3 px-3",
-                        "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:min-w-10 group-data-[collapsible=icon]:ml-1",
                         "data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:hover:bg-primary/90",
-                        "hover:bg-sidebar-accent"
+                        "hover:bg-sidebar-accent",
+                        // collapse 시 왼쪽 마진 12px 감소시켜서 아이콘 위치 조정
+                        "group-data-[collapsible=icon]:ml-[-12px]"
                       )}
                     >
                       <Link to={item.href}>
@@ -280,12 +263,9 @@ export function CommonSidebar() {
       </SidebarContent>
 
       {isLogin ? (
-        <SidebarFooter className={cn(
-          "p-3 border-t space-y-2",
-          "group-data-[collapsible=icon]:px-2"
-        )}>
+        <SidebarFooter className="p-3 border-t space-y-2">
           <SidebarMenu>
-            <SidebarMenuItem className="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
+            <SidebarMenuItem>
               <Link to="https://forms.gle/aLLsFtDBcMHqX9eQA" target="_blank">
                 <SidebarMenuButton
                   tooltip={{
@@ -296,9 +276,10 @@ export function CommonSidebar() {
                   }}
                   className={cn(
                     "h-10 justify-start gap-3 px-3 hover:bg-sidebar-accent",
-                    "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:min-w-10 group-data-[collapsible=icon]:ml-1"
+                    // collapse 시 왼쪽 마진 12px 감소시켜서 아이콘 위치 조정
+                    "group-data-[collapsible=icon]:ml-[-12px]"
                   )}
-                >
+                  >
                   <LifeBuoy className="size-5 shrink-0" />
 
                   <span className="truncate text-sm font-medium">피드백</span>
@@ -306,7 +287,7 @@ export function CommonSidebar() {
               </Link>
             </SidebarMenuItem>
 
-            <SidebarMenuItem className="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
+            <SidebarMenuItem>
               <SidebarMenuButton
                 onClick={logout}
                 tooltip={{
@@ -317,9 +298,10 @@ export function CommonSidebar() {
                 }}
                 className={cn(
                   "h-10 justify-start gap-3 px-3 text-red-500 hover:bg-red-500/10 hover:text-red-600",
-                  "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:min-w-10 group-data-[collapsible=icon]:ml-1"
+                  // collapse 시 왼쪽 마진 12px 감소시켜서 아이콘 위치 조정
+                  "group-data-[collapsible=icon]:ml-[-12px]"
                 )}
-              >
+                >
                 <LogOut className="size-5 shrink-0" />
                 <span className="truncate text-sm font-medium">로그아웃</span>
               </SidebarMenuButton>
@@ -327,38 +309,8 @@ export function CommonSidebar() {
           </SidebarMenu>
         </SidebarFooter>
       ) : (
-        <div className={cn(
-          "w-full flex justify-center items-center p-4",
-          "group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2"
-        )}>
-          <div className={cn(
-            "w-full max-w-full overflow-hidden",
-            // Collapse 상태에서 GoogleLogin 버튼 스타일링
-            "group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:mx-auto",
-            "group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center",
-            "group-data-[collapsible=icon]:relative group-data-[collapsible=icon]:overflow-hidden",
-            // GoogleLogin 버튼 내부 요소들 숨기기
-            "group-data-[collapsible=icon]:[&>div]:w-10 group-data-[collapsible=icon]:[&>div]:h-10",
-            "group-data-[collapsible=icon]:[&>div]:!min-width-0 group-data-[collapsible=icon]:[&>div]:overflow-hidden",
-            "group-data-[collapsible=icon]:[&>div>div]:w-10 group-data-[collapsible=icon]:[&>div>div]:h-10",
-            "group-data-[collapsible=icon]:[&>div>div]:!min-width-0 group-data-[collapsible=icon]:[&>div>div]:overflow-hidden",
-            "group-data-[collapsible=icon]:[&>div>div]:flex group-data-[collapsible=icon]:[&>div>div]:items-center group-data-[collapsible=icon]:[&>div>div]:justify-center",
-            // Border 제거
-            "group-data-[collapsible=icon]:[&>div]:border-0 group-data-[collapsible=icon]:[&>div]:!border-none",
-            "group-data-[collapsible=icon]:[&>div>div]:border-0 group-data-[collapsible=icon]:[&>div>div]:!border-none",
-            "group-data-[collapsible=icon]:[&_*]:border-0 group-data-[collapsible=icon]:[&_*]:!border-none",
-            // 배경색 통일
-            "group-data-[collapsible=icon]:[&>div]:bg-sidebar group-data-[collapsible=icon]:[&>div]:!bg-sidebar",
-            "group-data-[collapsible=icon]:[&>div>div]:bg-sidebar group-data-[collapsible=icon]:[&>div>div]:!bg-sidebar",
-            "group-data-[collapsible=icon]:[&_*]:bg-sidebar group-data-[collapsible=icon]:[&_*]:!bg-sidebar",
-            // 텍스트 숨기기
-            "group-data-[collapsible=icon]:[&_span]:hidden",
-            // 로고만 보이도록 조정
-            "group-data-[collapsible=icon]:[&_svg]:w-5 group-data-[collapsible=icon]:[&_svg]:h-5",
-            "group-data-[collapsible=icon]:[&_img]:w-5 group-data-[collapsible=icon]:[&_img]:h-5"
-          )}>
-            <GoogleButton />
-          </div>
+        <div className="w-full flex justify-center items-center p-4">
+          <GoogleButton />
         </div>
       )}
 

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -190,15 +190,24 @@ export function CommonSidebar() {
 
   return (
     <Sidebar collapsible="icon" className="border-r">
-      <SidebarHeader className="p-3 border-b">
-        <div className="flex justify-between items-center">
+      <SidebarHeader className={cn(
+        "p-3 border-b",
+        "group-data-[collapsible=icon]:px-2"
+      )}>
+        <div className={cn(
+          "flex justify-between items-center",
+          "group-data-[collapsible=icon]:justify-center"
+        )}>
           <Link
             to={paths.root}
-            className="flex items-center gap-3 p-2 rounded-lg transition-colors duration-200 hover:bg-sidebar-accent"
+            className={cn(
+              "flex items-center gap-3 p-2 rounded-lg transition-colors duration-200 hover:bg-sidebar-accent",
+              "group-data-[collapsible=icon]:hidden"
+            )}
           >
             <span
               className={cn(
-                "font-bold text-3xl group-data-[collapsible=icon]:hidden text-blue-400",
+                "font-bold text-3xl text-blue-400",
                 "transition-opacity duration-200 ease-in-out"
               )}
             >
@@ -206,11 +215,18 @@ export function CommonSidebar() {
             </span>
           </Link>
 
-          <SidebarTrigger className="mr-4" />
+          <SidebarTrigger 
+            className={cn(
+              "mr-4 group-data-[collapsible=icon]:mr-0"
+            )} 
+          />
         </div>
       </SidebarHeader>
 
-      <SidebarContent className="flex-1 p-3 space-y-1">
+      <SidebarContent className={cn(
+        "flex-1 p-3 space-y-1",
+        "group-data-[collapsible=icon]:px-2"
+      )}>
         {/* <RoleSwitcher /> */}
         {filteredNavGroups.map((group) => (
           <SidebarGroup key={group.title}>
@@ -225,7 +241,13 @@ export function CommonSidebar() {
             <SidebarGroupContent>
               <SidebarMenu>
                 {group.items.map((item) => (
-                  <SidebarMenuItem key={item.name}>
+                  <SidebarMenuItem 
+                    key={item.name}
+                    className={cn(
+                      "group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center",
+                      "group-data-[collapsible=icon]:pl-[8px]"
+                    )}
+                  >
                     <SidebarMenuButton
                       asChild
                       isActive={isActive(item.href)}
@@ -237,6 +259,7 @@ export function CommonSidebar() {
                       }}
                       className={cn(
                         "h-10 justify-start gap-3 px-3",
+                        "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:min-w-10 group-data-[collapsible=icon]:ml-1",
                         "data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:hover:bg-primary/90",
                         "hover:bg-sidebar-accent"
                       )}
@@ -257,9 +280,12 @@ export function CommonSidebar() {
       </SidebarContent>
 
       {isLogin ? (
-        <SidebarFooter className="p-3 border-t space-y-2">
+        <SidebarFooter className={cn(
+          "p-3 border-t space-y-2",
+          "group-data-[collapsible=icon]:px-2"
+        )}>
           <SidebarMenu>
-            <SidebarMenuItem>
+            <SidebarMenuItem className="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
               <Link to="https://forms.gle/aLLsFtDBcMHqX9eQA" target="_blank">
                 <SidebarMenuButton
                   tooltip={{
@@ -268,7 +294,10 @@ export function CommonSidebar() {
                     align: "center",
                     className: "bg-foreground text-background",
                   }}
-                  className="h-10 justify-start gap-3 px-3 hover:bg-sidebar-accent"
+                  className={cn(
+                    "h-10 justify-start gap-3 px-3 hover:bg-sidebar-accent",
+                    "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:min-w-10 group-data-[collapsible=icon]:ml-1"
+                  )}
                 >
                   <LifeBuoy className="size-5 shrink-0" />
 
@@ -277,7 +306,7 @@ export function CommonSidebar() {
               </Link>
             </SidebarMenuItem>
 
-            <SidebarMenuItem>
+            <SidebarMenuItem className="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
               <SidebarMenuButton
                 onClick={logout}
                 tooltip={{
@@ -286,7 +315,10 @@ export function CommonSidebar() {
                   align: "center",
                   className: "bg-foreground text-background",
                 }}
-                className="h-10 justify-start gap-3 px-3 text-red-500 hover:bg-red-500/10 hover:text-red-600"
+                className={cn(
+                  "h-10 justify-start gap-3 px-3 text-red-500 hover:bg-red-500/10 hover:text-red-600",
+                  "group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:min-w-10 group-data-[collapsible=icon]:ml-1"
+                )}
               >
                 <LogOut className="size-5 shrink-0" />
                 <span className="truncate text-sm font-medium">로그아웃</span>
@@ -295,8 +327,38 @@ export function CommonSidebar() {
           </SidebarMenu>
         </SidebarFooter>
       ) : (
-        <div className="w-full flex justify-center items-center p-4">
-          <GoogleButton />
+        <div className={cn(
+          "w-full flex justify-center items-center p-4",
+          "group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:py-2"
+        )}>
+          <div className={cn(
+            "w-full max-w-full overflow-hidden",
+            // Collapse 상태에서 GoogleLogin 버튼 스타일링
+            "group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:h-10 group-data-[collapsible=icon]:mx-auto",
+            "group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center",
+            "group-data-[collapsible=icon]:relative group-data-[collapsible=icon]:overflow-hidden",
+            // GoogleLogin 버튼 내부 요소들 숨기기
+            "group-data-[collapsible=icon]:[&>div]:w-10 group-data-[collapsible=icon]:[&>div]:h-10",
+            "group-data-[collapsible=icon]:[&>div]:!min-width-0 group-data-[collapsible=icon]:[&>div]:overflow-hidden",
+            "group-data-[collapsible=icon]:[&>div>div]:w-10 group-data-[collapsible=icon]:[&>div>div]:h-10",
+            "group-data-[collapsible=icon]:[&>div>div]:!min-width-0 group-data-[collapsible=icon]:[&>div>div]:overflow-hidden",
+            "group-data-[collapsible=icon]:[&>div>div]:flex group-data-[collapsible=icon]:[&>div>div]:items-center group-data-[collapsible=icon]:[&>div>div]:justify-center",
+            // Border 제거
+            "group-data-[collapsible=icon]:[&>div]:border-0 group-data-[collapsible=icon]:[&>div]:!border-none",
+            "group-data-[collapsible=icon]:[&>div>div]:border-0 group-data-[collapsible=icon]:[&>div>div]:!border-none",
+            "group-data-[collapsible=icon]:[&_*]:border-0 group-data-[collapsible=icon]:[&_*]:!border-none",
+            // 배경색 통일
+            "group-data-[collapsible=icon]:[&>div]:bg-sidebar group-data-[collapsible=icon]:[&>div]:!bg-sidebar",
+            "group-data-[collapsible=icon]:[&>div>div]:bg-sidebar group-data-[collapsible=icon]:[&>div>div]:!bg-sidebar",
+            "group-data-[collapsible=icon]:[&_*]:bg-sidebar group-data-[collapsible=icon]:[&_*]:!bg-sidebar",
+            // 텍스트 숨기기
+            "group-data-[collapsible=icon]:[&_span]:hidden",
+            // 로고만 보이도록 조정
+            "group-data-[collapsible=icon]:[&_svg]:w-5 group-data-[collapsible=icon]:[&_svg]:h-5",
+            "group-data-[collapsible=icon]:[&_img]:w-5 group-data-[collapsible=icon]:[&_img]:h-5"
+          )}>
+            <GoogleButton />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## 작업 사항
### SidebarHeader
- `SidebarTrigger` 위치 조정 (`mr-4 → group-data-[collapsible=icon]:mr-0`)
- Collapsed 상태에서 로고 영역(`HIStudy`) 숨김 처리 및 padding 최적화

### SidebarContent
- Collapsed 상태에서 `px-2` 적용
- `SidebarMenuItem`, `SidebarMenuButton`에 `justify-center`, `w-10`, `min-w-10` 등 추가하여 아이콘 정렬 개선

### SidebarFooter
- 비로그인 상태일 때
  - **Google 로그인 버튼** → Collapsed 시 정사각형 버튼처럼 표시
  - 내부 요소(텍스트, border 등) 숨기고 로고만 보이게 수정
 - 로그인 상태일 때(테스트 필요..)
  - **피드백** / **로그아웃** 버튼 → Collapsed 시 아이콘만 보이도록 스타일 조정

### 공통 변경 사항
- 여러 곳에서 `cn()`을 사용하여 조건부 클래스 정리
- Collapsed 모드(`group-data-[collapsible=icon]`) 대응 스타일 추가


## 관련 이슈
- 기존 사이드바는 **Collapsed 모드에서 레이아웃 깨짐 / 구글 로그인 버튼 이탈** 문제 존재
- Collapsed 상태에서도 **깔끔한 UI** 유지
- 버튼/Google 로그인 컴포넌트도 일관성 있게 대응하도록 개선

*확인사항: 로그인된 환경에서는 아직 테스트 해보지 못함

close #137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사이드바의 아이콘 전용 접기 모드에서 아이콘과 텍스트가 좌측으로 미세 이동해 정렬이 개선됩니다.
  * 사이드바 상태에 따라 구글 로그인 버튼이 아이콘형/표준형으로 자동 전환됩니다.

* **스타일**
  * 헤더·메뉴·로그아웃·피드백 항목 등 접힘 상태에 맞춰 간격과 정렬이 최적화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->