### PR TITLE
스터디 신청 인원 중에서 그룹 미배정 목록을 불러오도록 API 변경

### DIFF
--- a/src/pages/Admin/ManageGroup/Page.tsx
+++ b/src/pages/Admin/ManageGroup/Page.tsx
@@ -1,4 +1,4 @@
-import { readAllGroups, readUngroup } from "@/apis/manager";
+import { readAllGroups, readApplicants } from "@/apis/manager";
 import { useMemo } from "react";
 import { useQueries } from "react-query";
 import GroupTable from "./components/GroupTable";
@@ -15,7 +15,7 @@ export default function MatchedGroupListPage() {
     },
     {
       queryKey: ["ungroups"],
-      queryFn: readUngroup,
+      queryFn: readApplicants,
       cacheTime: 5 * 60 * 1000,
     },
   ]);


### PR DESCRIPTION
## 작업 사항

- 관리자 탭 "스터디 그룹 매칭 관리"에 있는 "미매칭 학생 목록" 섹션에 대한 데이터 API를 `/api/admin/unmatched-users` -> `/api/admin/users/unassigned`로 변경 ("스터디 그룹 생성" 탭 API와 동일)

기존에는 스터디 신청 여부와 관계없이 미배정된 모든 학생 목록을 불러왔습니다. 그러나 이번 학기 스터디를 신청한 학생을 찾아 배정하는 과정이 관리자 입장에서 불편할 수 있다고 판단했습니다.

“미매칭 학생 목록” 섹션은 주로

	1.	자동 배정된 그룹에서 특정 학생을 미배정 상태로 변경(다른 그룹으로 이동)
	2.	자동 배정되지 않은 학생을 수동으로 그룹 배정하는 경우

에 사용됩니다. 두 경우 모두 학생이 스터디를 신청했으므로, 신청 여부와 관계없이 미배정 학생을 불러오기보다는 신청한 학생 중 미배정 학생을 반환하는 API로 변경하는 것이 적절하다고 판단했습니다.

또한, 스터디 신청 기한이 지난 상태에서 미배정 학생이 그룹 배정을 희망할 경우에는, 먼저 스터디 신청을 안내한 뒤 그룹에 배정하는 흐름이 더 자연스럽다고 생각합니다.

**응답 포맷은 동일하므로, API 변경에 따른 응답 필드 수정은 필요 없습니다. (개발계 테스트 완료)**


## 관련 이슈

없음
